### PR TITLE
Zero-initialize `struct fuse_operations`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -251,10 +251,6 @@ main (int argc, char **argv)
     fuse7z_oper.getxattr = fuse7z_getxattr;
     fuse7z_oper.listxattr = fuse7z_listxattr;
     fuse7z_oper.removexattr = fuse7z_removexattr;
-    #if FUSE_VERSION >= 28
-    // don't allow nullptr path
-    fuse7z_oper.flag_nullpath_ok = 0;
-    #endif
     struct fuse * fuse = fuse_setup (
                 args.argc, args.argv,
                 &fuse7z_oper, sizeof(fuse7z_oper),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -218,7 +218,7 @@ main (int argc, char **argv)
         
     }
 
-    struct fuse_operations fuse7z_oper;
+    struct fuse_operations fuse7z_oper = {0};
     fuse7z_oper.init = fuse7z_init;
     fuse7z_oper.destroy = fuse7z_destroy;
     fuse7z_oper.readdir = fuse7z_readdir;


### PR DESCRIPTION
Fixes segfault when reading archive files on newer systems.